### PR TITLE
Fix on connection string

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,7 +8,7 @@ services:
             context: .
             dockerfile: dockerfile
         environment:
-            - ConnectionStrings__Context=Server=architecture_database;Database=Database;User Id=sa;Password=P4ssW0rd!;
+            - ConnectionStrings__Context=Server=architecture_database;Database=Database;User Id=sa;Password=P4ssW0rd!;TrustServerCertificate=true;
             - Serilog__WriteTo__1__Args__path=/app/logs/
         depends_on:
             - database


### PR DESCRIPTION
The application cannot connect to the database when its container is raised. As a connection error appears due to an untrusted certificate.